### PR TITLE
Migrating from Pyknow, because Pyknow is Deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Using expert system shells for the development of Expert systems. These shells a
 
 Package Used
 --------------
-Pyknow
+experta==1.9.4
 
 Idea
 ------------------

--- a/medical_expert_system.py
+++ b/medical_expert_system.py
@@ -1,4 +1,4 @@
-from pyknow import *
+from experta import *
 
 diseases_list = []
 diseases_symptoms = []


### PR DESCRIPTION
Since the Pyknow Library is now Deprecated, Just replaced pyknow references to experta as Experta is a Pyknow fork.